### PR TITLE
Resource group customization (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ A guide on how to create organzizations and spaces can be found [here](https://c
   - name: YOUR-APP
   ```
 
+* RESOURCE_GROUP (optional)
+
+  A resource group is a way for you to organize your account resources in customizable groupings. Details about resource groups and how to set them up can be found [here](https://cloud.ibm.com/docs/account?topic=cli-ibmcloud_commands_resource)
+
+
 ### Workflow Example
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: App Manifest file
     required: false
     default: manifest.yml
+  RESOURCE_GROUP:
+    description: IBM Cloud Foundry resource group
+    required: false
 
 
 runs:
@@ -35,7 +38,7 @@ runs:
       run: ibmcloud cf install
       shell: bash
     - name: Authenticate with IBM Cloud CLI
-      run: ibmcloud login --apikey "${{ inputs.IBM_CLOUD_API_KEY }}" --no-region -g default
+      run: ibmcloud login --apikey "${{ inputs.IBM_CLOUD_API_KEY }}" --no-region $( [[ ! -z "${{ inputs.RESOURCE_GROUP }}" ]] && echo "-g ${{ inputs.RESOURCE_GROUP }}")
       shell: bash
     - name: Target a Cloud Foundry org and space
       run: ibmcloud target --cf-api "${{ inputs.IBM_CLOUD_CF_API }}" -o "${{ inputs.IBM_CLOUD_CF_ORG }}" -s "${{ inputs.IBM_CLOUD_CF_SPACE }}"


### PR DESCRIPTION
This PR introduces a new parameter/input `RESOURCE_GROUP`. If defined the provided resource group will be selected. Otherwise resource groups will not be used.

This PR is competing with #5. Both can't be merged due to conflicts. We have to create a v1 and v2 branch to differentiate between both solutions. 